### PR TITLE
Add debug console logging for Habr jobs plugin

### DIFF
--- a/chrome/jobs/habr/popup.js
+++ b/chrome/jobs/habr/popup.js
@@ -1,18 +1,30 @@
+console.debug('Habr jobs plugin script loaded');
+
+window.addEventListener('unload', () => {
+  console.debug('Habr jobs plugin stopped');
+});
+
 document.addEventListener('DOMContentLoaded', () => {
+  console.debug('Habr jobs plugin started');
+
   const folderInput = document.getElementById('folder');
   const fileInput = document.getElementById('filename');
   const saveBtn = document.getElementById('save');
 
   folderInput.value = localStorage.getItem('folder') || '';
   fileInput.value = localStorage.getItem('filename') || 'vacancies.json';
+  console.debug('Loaded initial settings', { folder: folderInput.value, filename: fileInput.value });
 
   saveBtn.addEventListener('click', async () => {
+    console.debug('Save button clicked');
     const folder = folderInput.value.trim() || '';
     const filename = fileInput.value.trim() || 'vacancies.json';
     localStorage.setItem('folder', folder);
     localStorage.setItem('filename', filename);
+    console.debug('Settings saved', { folder, filename });
 
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    console.debug('Active tab retrieved', tab);
     const [{ result }] = await chrome.scripting.executeScript({
       target: { tabId: tab.id },
       func: () => {
@@ -28,12 +40,16 @@ document.addEventListener('DOMContentLoaded', () => {
         });
       }
     });
+    console.debug(`Extracted ${result.length} vacancies`, result);
 
     const blob = new Blob([JSON.stringify(result, null, 2)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     const path = folder ? `${folder.replace(/\\$/,'')}/${filename}` : filename;
-    chrome.downloads.download({ url, filename: path, saveAs: false }, () => {
+    console.debug('Initiating download', { path });
+    chrome.downloads.download({ url, filename: path, saveAs: false }, downloadId => {
+      console.debug('Download started', downloadId);
       URL.revokeObjectURL(url);
+      console.debug('Closing popup window');
       window.close();
     });
   });


### PR DESCRIPTION
## Summary
- log plugin lifecycle events (load/start/stop) in the Habr jobs extension
- capture additional debug info such as settings, active tab, vacancy count and download status

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a6b2c750c8322bfd116f87107c3b8