### PR TITLE
Add simple Fastify GraphQL server example

### DIFF
--- a/fastify/README.md
+++ b/fastify/README.md
@@ -1,0 +1,37 @@
+# Fastify GraphQL Example
+
+This example demonstrates a basic [Fastify](https://www.fastify.io/) server exposing a GraphQL API using [Mercurius](https://mercurius.dev/).
+
+The schema defines a single query, `add`, which returns the sum of two integers.
+
+## Setup
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+## Running the server
+
+```bash
+npm start
+```
+
+The server listens on [http://localhost:3000](http://localhost:3000) and provides a GraphiQL interface at `/graphiql`.
+
+## Testing
+
+Send a GraphQL request to verify the `add` resolver:
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+  --data '{ "query": "{ add(x: 1, y: 2) }" }' \
+  http://localhost:3000/graphql
+```
+
+The response should be:
+
+```json
+{"data":{"add":3}}
+```

--- a/fastify/index.js
+++ b/fastify/index.js
@@ -1,0 +1,30 @@
+const Fastify = require('fastify');
+const mercurius = require('mercurius');
+
+const app = Fastify();
+
+const schema = `
+  type Query {
+    add(x: Int!, y: Int!): Int!
+  }
+`;
+
+const resolvers = {
+  Query: {
+    add: async (_, { x, y }) => x + y,
+  },
+};
+
+app.register(mercurius, {
+  schema,
+  resolvers,
+  graphiql: true,
+});
+
+app.listen({ port: 3000 }, err => {
+  if (err) {
+    app.log.error(err);
+    process.exit(1);
+  }
+  console.log('Server listening at http://localhost:3000');
+});

--- a/fastify/package.json
+++ b/fastify/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "fastify-graphql-app",
+  "version": "1.0.0",
+  "description": "Simple Fastify server with GraphQL",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "fastify": "^4.0.0",
+    "mercurius": "^13.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add simple Fastify server with GraphQL schema and resolvers
- document setup, running and curl-based testing steps

## Testing
- `npm install`
- `node index.js &` then `curl -X POST -H "Content-Type: application/json" --data '{ "query": "{ add(x: 1, y: 2) }" }' http://localhost:3000/graphql`


------
https://chatgpt.com/codex/tasks/task_e_689c65d3c14c832292d1562a2528c8d4