### PR TITLE
Add PWA push notification example

### DIFF
--- a/projects/pwa-notification/.gitignore
+++ b/projects/pwa-notification/.gitignore
@@ -1,0 +1,20 @@
+# Node modules
+node_modules/
+**/node_modules/
+
+# Build output
+**/dist/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# dotenv environment files
+.env
+
+# Lock files
+package-lock.json
+
+# Icon assets
+public/icons/

--- a/projects/pwa-notification/README.md
+++ b/projects/pwa-notification/README.md
@@ -1,0 +1,34 @@
+# PWA Push Notification Example
+
+This example demonstrates a very small Progressive Web App (PWA) that subscribes a device to push notifications and allows a Node.js server to send a message to it.
+
+## Prerequisites
+- Node.js 18+
+- npm
+- For testing on a real phone the app must be served over **HTTPS**. On `localhost` HTTP is allowed.
+
+## Installation
+```bash
+npm install
+```
+
+## Running
+```bash
+npm start
+```
+The server will run on `http://localhost:3000` and serve the contents of the `public` folder.
+
+### Testing on a phone
+1. Make sure the phone is on the same network as your development machine.
+2. Expose the server through HTTPS using a tunnel such as [ngrok](https://ngrok.com/) or by configuring a TLS certificate.
+3. Open the served URL in the phone's browser.
+4. Use "Add to home screen" to install the PWA.
+5. Tap **Subscribe & Send Notification**. The device will request permission and the server will send a test notification.
+
+## How it works
+- `public/app.js` registers a service worker and subscribes to push notifications using the VAPID public key.
+- `server.js` stores subscriptions in memory and has two endpoints:
+  - `POST /subscribe` – saves a subscription.
+  - `POST /notify` – sends a sample push message to all stored subscriptions.
+
+This project is for demonstration purposes only. Do not use the included VAPID keys in production.

--- a/projects/pwa-notification/package.json
+++ b/projects/pwa-notification/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "pwa-notification-example",
+  "version": "1.0.0",
+  "description": "Simple PWA that sends push notification",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "web-push": "^3.6.0"
+  }
+}

--- a/projects/pwa-notification/public/app.js
+++ b/projects/pwa-notification/public/app.js
@@ -1,0 +1,37 @@
+const publicVapidKey = 'BO2catiBPz9_i-1sWVnAvu_novcJLH2jGIuFUfjqoKiihDilIZOOTRMM-NNvCmnFVZPru6648jKp8S7kHaIJIFA';
+
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/sw.js').catch(err => console.error('SW registration failed', err));
+}
+
+document.getElementById('notify').addEventListener('click', async () => {
+  const permission = await Notification.requestPermission();
+  if (permission !== 'granted') {
+    alert('Permission denied');
+    return;
+  }
+  const registration = await navigator.serviceWorker.ready;
+  const subscription = await registration.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: urlBase64ToUint8Array(publicVapidKey)
+  });
+
+  await fetch('/subscribe', {
+    method: 'POST',
+    body: JSON.stringify(subscription),
+    headers: { 'Content-Type': 'application/json' }
+  });
+
+  await fetch('/notify', { method: 'POST' });
+});
+
+function urlBase64ToUint8Array(base64String) {
+  const padding = '='.repeat((4 - base64String.length % 4) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = window.atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+  for (let i = 0; i < rawData.length; ++i) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+}

--- a/projects/pwa-notification/public/index.html
+++ b/projects/pwa-notification/public/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>PWA Push Example</title>
+  <link rel="manifest" href="manifest.json" />
+  <script defer src="app.js"></script>
+</head>
+<body>
+  <h1>PWA Push Notification Example</h1>
+  <button id="notify">Subscribe & Send Notification</button>
+</body>
+</html>

--- a/projects/pwa-notification/public/manifest.json
+++ b/projects/pwa-notification/public/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "PWA Push Example",
+  "short_name": "PushPWA",
+  "start_url": "/index.html",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "description": "A simple PWA that receives push notifications"
+}

--- a/projects/pwa-notification/public/sw.js
+++ b/projects/pwa-notification/public/sw.js
@@ -1,0 +1,8 @@
+self.addEventListener('push', event => {
+  const data = event.data ? event.data.json() : {};
+  event.waitUntil(
+    self.registration.showNotification(data.title || 'Notification', {
+      body: data.body || 'You have a new message'
+    })
+  );
+});

--- a/projects/pwa-notification/server.js
+++ b/projects/pwa-notification/server.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const webpush = require('web-push');
+const path = require('path');
+
+const app = express();
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+// VAPID keys should be generated only once.
+const publicVapidKey = 'BO2catiBPz9_i-1sWVnAvu_novcJLH2jGIuFUfjqoKiihDilIZOOTRMM-NNvCmnFVZPru6648jKp8S7kHaIJIFA';
+const privateVapidKey = 'dacUaSaTnzsEx3oWINyCT60p6H8NSiCj_IHEg01bh1I';
+webpush.setVapidDetails('mailto:example@example.com', publicVapidKey, privateVapidKey);
+
+// Store subscriptions in memory for demo purposes
+const subscriptions = [];
+
+app.post('/subscribe', (req, res) => {
+  const subscription = req.body;
+  subscriptions.push(subscription);
+  res.status(201).json({});
+});
+
+app.post('/notify', async (req, res) => {
+  const payload = JSON.stringify({ title: 'PWA Notification', body: 'Hello from the server!' });
+  const sendPromises = subscriptions.map(sub => webpush.sendNotification(sub, payload).catch(err => console.error(err)));
+  await Promise.all(sendPromises);
+  res.status(200).json({});
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => console.log(`Server started on port ${port}`));


### PR DESCRIPTION
## Summary
- remove `package-lock.json` and icon PNGs from PWA example
- restrict `.gitignore` to PWA project with lock and icon exclusions
- clean manifest after dropping icons

## Testing
- `npm test`
- `npm install --prefix projects/pwa-notification`
- `node projects/pwa-notification/server.js`


------
https://chatgpt.com/codex/tasks/task_e_68aecbec85e08322923f5ee807752ae6