### PR TITLE
Add job_meta Chrome extension project

### DIFF
--- a/job_meta/.gitignore
+++ b/job_meta/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/job_meta/README.md
+++ b/job_meta/README.md
@@ -1,0 +1,16 @@
+# Job Meta Chrome Extension
+
+This Chrome extension processes Markdown documents in a chosen directory.
+
+- Select a folder containing `.md` documents.
+- Each document receives or updates a `lastOpened` attribute in its front matter.
+- Documents are converted to HTML files in the same folder.
+- When debug mode is enabled, detailed logs are printed to the console and only the first document is processed.
+
+## Usage
+1. Load the extension in Chrome via `chrome://extensions` and enable Developer Mode.
+2. Click **Load unpacked** and choose this `job_meta` folder.
+3. Open the extension popup, optionally enable **Debug**, and select a folder of Markdown documents.
+
+## Development
+No build step is required; the extension uses standard web APIs.

--- a/job_meta/manifest.json
+++ b/job_meta/manifest.json
@@ -1,0 +1,11 @@
+{
+  "manifest_version": 3,
+  "name": "Job Meta",
+  "version": "1.0",
+  "description": "Process Markdown files, record last opened time, and output HTML.",
+  "permissions": ["storage"],
+  "action": {
+    "default_title": "Process Markdown",
+    "default_popup": "popup.html"
+  }
+}

--- a/job_meta/popup.html
+++ b/job_meta/popup.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Job Meta</title>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+</head>
+<body>
+  <label><input type="checkbox" id="debug"> Debug</label>
+  <button id="select-folder">Select Folder</button>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/job_meta/popup.js
+++ b/job_meta/popup.js
@@ -1,0 +1,80 @@
+let debug = false;
+function log(...args) {
+  if (debug) {
+    console.log(...args);
+  }
+}
+
+async function updateLastOpened(text) {
+  const iso = new Date().toISOString();
+  const fm = text.match(/^---\n([\s\S]*?)\n---\n/);
+  if (fm) {
+    let body = fm[1];
+    if (/lastOpened:\s*.*/.test(body)) {
+      body = body.replace(/lastOpened:\s*.*/, `lastOpened: ${iso}`);
+      log('Replaced existing lastOpened with', iso);
+    } else {
+      body += `\nlastOpened: ${iso}`;
+      log('Added lastOpened to front matter', iso);
+    }
+    return { text: `---\n${body}\n---\n` + text.slice(fm[0].length), iso };
+  }
+  log('Created front matter with lastOpened', iso);
+  return { text: `---\nlastOpened: ${iso}\n---\n` + text, iso };
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const folderBtn = document.getElementById('select-folder');
+  const debugChk = document.getElementById('debug');
+
+  chrome.storage.sync.get({ debug: false }, ({ debug: stored }) => {
+    debug = stored;
+    debugChk.checked = debug;
+    log('Initial debug mode', debug);
+  });
+
+  debugChk.addEventListener('change', () => {
+    debug = debugChk.checked;
+    chrome.storage.sync.set({ debug });
+    log('Debug mode set to', debug);
+  });
+
+  folderBtn.addEventListener('click', async () => {
+    const dirHandle = await window.showDirectoryPicker();
+    log('Selected directory', dirHandle.name);
+    let processed = 0;
+    for await (const [name, handle] of dirHandle.entries()) {
+      if (handle.kind === 'file' && name.endsWith('.md')) {
+        log('Processing file', name);
+        const file = await handle.getFile();
+        log('Read file', name);
+        const originalText = await file.text();
+        const { text, iso } = await updateLastOpened(originalText);
+        log('lastOpened set to', iso);
+        const writable = await handle.createWritable();
+        await writable.write(text);
+        await writable.close();
+        log('Wrote updated Markdown to', name);
+
+        const html = marked.parse(text);
+        const htmlName = name.replace(/\.md$/, '.html');
+        log('Generated HTML for', name);
+        const htmlHandle = await dirHandle.getFileHandle(htmlName, {
+          create: true,
+        });
+        const htmlWritable = await htmlHandle.createWritable();
+        await htmlWritable.write(html);
+        await htmlWritable.close();
+        log('Wrote HTML to', htmlName);
+
+        processed++;
+        log('Processed files count', processed);
+        if (debug && processed >= 1) {
+          log('Debug mode: stopping after first file');
+          break;
+        }
+      }
+    }
+    log('Finished processing', processed, 'files');
+  });
+});


### PR DESCRIPTION
## Summary
- add job_meta Chrome extension to process Markdown files and track last opened timestamps
- include popup UI to select folder, toggle debug mode, and convert Markdown to HTML
- log details of each operation and its result when debug mode is enabled

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd6b14def88322a77e75c78e89a07b