### PR TITLE
Add test_020 Chrome extension

### DIFF
--- a/test_020/.gitignore
+++ b/test_020/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.zip

--- a/test_020/README.md
+++ b/test_020/README.md
@@ -1,0 +1,18 @@
+# test_020
+
+Chrome extension that lets you choose a folder of Markdown files,
+shows the folder path and lists up to the first ten file names.
+A debug checkbox limits processing to a single file and logs
+detailed operations to the console.
+
+## Features
+- Choose a directory containing Markdown files.
+- Display the selected folder in the popup.
+- List first ten `.md` files (or one in debug mode).
+- Debug mode logs each operation and result.
+
+## Usage
+1. Load the extension in Chrome via `chrome://extensions` with Developer mode enabled.
+2. Click the extension icon to open the popup.
+3. Optionally enable **Debug** to log operations and only process one file.
+4. Use the folder picker to select a directory of Markdown documents. The file names will appear in the list.

--- a/test_020/manifest.json
+++ b/test_020/manifest.json
@@ -1,0 +1,9 @@
+{
+  "manifest_version": 3,
+  "name": "test_020",
+  "version": "1.0",
+  "description": "Select a folder of Markdown documents and list file names.",
+  "action": {
+    "default_popup": "popup.html"
+  }
+}

--- a/test_020/popup.html
+++ b/test_020/popup.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>test_020</title>
+  <style>
+    body { font-family: sans-serif; margin: 10px; }
+    ul { padding-left: 20px; }
+  </style>
+</head>
+<body>
+  <label><input type="checkbox" id="debugToggle"> Debug</label>
+  <div>
+    <input type="file" id="folderPicker" webkitdirectory multiple>
+  </div>
+  <div id="folderDisplay"></div>
+  <ul id="fileList"></ul>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/test_020/popup.js
+++ b/test_020/popup.js
@@ -1,0 +1,39 @@
+const debugToggle = document.getElementById('debugToggle');
+const folderPicker = document.getElementById('folderPicker');
+const folderDisplay = document.getElementById('folderDisplay');
+const fileList = document.getElementById('fileList');
+
+let debug = false;
+
+function log(...args) {
+  if (debug) {
+    console.log(...args);
+  }
+}
+
+debugToggle.addEventListener('change', () => {
+  debug = debugToggle.checked;
+  log('Debug mode:', debug);
+});
+
+folderPicker.addEventListener('change', (e) => {
+  const files = Array.from(e.target.files).filter(f => f.name.endsWith('.md'));
+  if (files.length === 0) {
+    folderDisplay.textContent = 'No markdown files found.';
+    fileList.innerHTML = '';
+    log('No markdown files found');
+    return;
+  }
+
+  const firstPath = files[0].webkitRelativePath;
+  const folderPath = firstPath.substring(0, firstPath.lastIndexOf('/'));
+  folderDisplay.textContent = 'Selected folder: ' + folderPath;
+  log('Selected folder:', folderPath);
+
+  const limit = debug ? 1 : 10;
+  const names = files.slice(0, limit).map(f => f.name);
+  fileList.innerHTML = names.map(n => `<li>${n}</li>`).join('');
+
+  names.forEach(name => log('Processed file:', name));
+  log('Done');
+});


### PR DESCRIPTION
## Summary
- add `test_020` extension that lists Markdown filenames from a chosen folder
- implement debug checkbox to limit processing and log operations
- document extension usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bea39f324483229e3c851f734efe64