### PR TITLE
feat: add standalone HTML page based on test_020 plugin

### DIFF
--- a/projects/test_030/README.md
+++ b/projects/test_030/README.md
@@ -1,0 +1,17 @@
+# test_030
+
+Simple HTML page that lets you choose a folder of Markdown files,
+shows the folder path and lists up to the first ten file names.
+A debug checkbox limits processing to a single file and logs
+detailed operations to the console.
+
+## Features
+- Choose a directory containing Markdown files.
+- Display the selected folder in the page.
+- List first ten `.md` files (or one in debug mode).
+- Debug mode logs each operation and result.
+
+## Usage
+1. Open `index.html` in a modern browser.
+2. Optionally enable **Debug** to log operations and only process one file.
+3. Use the folder picker to select a directory of Markdown documents. The file names will appear in the list.

--- a/projects/test_030/index.html
+++ b/projects/test_030/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>test_030</title>
+  <style>
+    body { font-family: sans-serif; margin: 10px; }
+    ul { padding-left: 20px; }
+  </style>
+</head>
+<body>
+  <label><input type="checkbox" id="debugToggle"> Debug</label>
+  <div>
+    <input type="file" id="folderPicker" webkitdirectory multiple>
+  </div>
+  <div id="folderDisplay"></div>
+  <ul id="fileList"></ul>
+  <script>
+    const debugToggle = document.getElementById('debugToggle');
+    const folderPicker = document.getElementById('folderPicker');
+    const folderDisplay = document.getElementById('folderDisplay');
+    const fileList = document.getElementById('fileList');
+
+    let debug = false;
+
+    function log(...args) {
+      if (debug) {
+        console.log(...args);
+      }
+    }
+
+    debugToggle.addEventListener('change', () => {
+      debug = debugToggle.checked;
+      log('Debug mode:', debug);
+    });
+
+    folderPicker.addEventListener('change', (e) => {
+      const files = Array.from(e.target.files).filter(f => f.name.endsWith('.md'));
+      if (files.length === 0) {
+        folderDisplay.textContent = 'No markdown files found.';
+        fileList.innerHTML = '';
+        log('No markdown files found');
+        return;
+      }
+
+      const firstPath = files[0].webkitRelativePath;
+      const folderPath = firstPath.substring(0, firstPath.lastIndexOf('/'));
+      folderDisplay.textContent = 'Selected folder: ' + folderPath;
+      log('Selected folder:', folderPath);
+
+      const limit = debug ? 1 : 10;
+      const names = files.slice(0, limit).map(f => f.name);
+      fileList.innerHTML = names.map(n => `<li>${n}</li>`).join('');
+
+      names.forEach(name => log('Processed file:', name));
+      log('Done');
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- ported test_020 popup into a standalone HTML page
- documented usage of the new page
- moved the project under projects/test_030

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c56634154c8322b3e22909757ce01f