### PR TITLE
fix: stabilize test_020 plugin and add standalone HTML page

### DIFF
--- a/projects/test_020/README.md
+++ b/projects/test_020/README.md
@@ -4,15 +4,15 @@ Chrome extension that lets you choose a folder of Markdown files,
 shows the folder path and lists up to the first ten file names.
 Files are processed one at a time to avoid freezes when large
 directories are selected. A debug checkbox limits processing to a
-single file and logs detailed operations to `log.txt`.
+single file and logs detailed operations to the console.
 
 ## Features
 - Choose a directory containing Markdown files.
 - Display the selected folder in the popup.
 - List first ten `.md` files (or one in debug mode).
-- Debug mode logs each operation and result to `log.txt` in the extension folder.
+- Debug mode logs each operation and result to the console.
 ## Usage
 1. Load the extension in Chrome via `chrome://extensions` with Developer mode enabled.
 2. Click the extension icon to open the popup.
-3. Optionally enable **Debug** to log operations to `log.txt` and only process one file.
+3. Optionally enable **Debug** to log operations to the console and only process one file.
 4. Use the folder picker to select a directory of Markdown documents. The file names will appear in the list.

--- a/projects/test_020/popup.js
+++ b/projects/test_020/popup.js
@@ -4,32 +4,10 @@ const folderDisplay = document.getElementById('folderDisplay');
 const fileList = document.getElementById('fileList');
 
 let debug = false;
-let logFileEntry;
-
-// Prepare log file in the extension directory
-try {
-  chrome.runtime.getPackageDirectoryEntry(root => {
-    root.getFile('log.txt', { create: true }, fileEntry => {
-      logFileEntry = fileEntry;
-    });
-  });
-} catch (e) {
-  // In environments where this API isn't available, logs will only go to console
-  console.error('Log file init failed', e);
-}
 
 function log(...args) {
-  if (!debug) return;
-  const message = args.join(' ');
-  console.log(message);
-
-  if (logFileEntry) {
-    logFileEntry.createWriter(writer => {
-      logFileEntry.file(file => {
-        writer.seek(file.size);
-        writer.write(new Blob([message + '\n'], { type: 'text/plain' }));
-      });
-    });
+  if (debug) {
+    console.log(...args);
   }
 }
 
@@ -39,38 +17,23 @@ debugToggle.addEventListener('change', () => {
 });
 
 folderPicker.addEventListener('change', (e) => {
-  try {
-    const limit = debug ? 1 : 10;
-    const names = [];
-    let folderPath = '';
-
-    for (const file of e.target.files) {
-      if (!file.name.endsWith('.md')) continue;
-
-      if (!folderPath && file.webkitRelativePath) {
-        const firstPath = file.webkitRelativePath;
-        folderPath = firstPath.substring(0, firstPath.lastIndexOf('/'));
-        folderDisplay.textContent = 'Selected folder: ' + folderPath;
-        log('Selected folder:', folderPath);
-      }
-
-      names.push(file.name);
-      if (names.length >= limit) break;
-    }
-
-    if (names.length === 0) {
-      folderDisplay.textContent = 'No markdown files found.';
-      fileList.innerHTML = '';
-      log('No markdown files found');
-      return;
-    }
-
-    fileList.innerHTML = names.map(n => `<li>${n}</li>`).join('');
-    names.forEach(name => log('Processed file:', name));
-    log('Done');
-  } catch (err) {
-    folderDisplay.textContent = 'Error reading files';
-    console.error(err);
-    log('Error:', err.message);
+  const files = Array.from(e.target.files).filter(f => f.name.endsWith('.md'));
+  if (files.length === 0) {
+    folderDisplay.textContent = 'No markdown files found.';
+    fileList.innerHTML = '';
+    log('No markdown files found');
+    return;
   }
+
+  const firstPath = files[0].webkitRelativePath;
+  const folderPath = firstPath.substring(0, firstPath.lastIndexOf('/'));
+  folderDisplay.textContent = 'Selected folder: ' + folderPath;
+  log('Selected folder:', folderPath);
+
+  const limit = debug ? 1 : 10;
+  const names = files.slice(0, limit).map(f => f.name);
+  fileList.innerHTML = names.map(n => `<li>${n}</li>`).join('');
+
+  names.forEach(name => log('Processed file:', name));
+  log('Done');
 });

--- a/projects/test_030/README.md
+++ b/projects/test_030/README.md
@@ -1,0 +1,17 @@
+# test_030
+
+Simple HTML page that lets you choose a folder of Markdown files,
+shows the folder path and lists up to the first ten file names.
+A debug checkbox limits processing to a single file and logs
+detailed operations to the console.
+
+## Features
+- Choose a directory containing Markdown files.
+- Display the selected folder in the page.
+- List first ten `.md` files (or one in debug mode).
+- Debug mode logs each operation and result.
+
+## Usage
+1. Open `index.html` in a modern browser.
+2. Optionally enable **Debug** to log operations and only process one file.
+3. Use the folder picker to select a directory of Markdown documents. The file names will appear in the list.

--- a/projects/test_030/index.html
+++ b/projects/test_030/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>test_030</title>
+  <style>
+    body { font-family: sans-serif; margin: 10px; }
+    ul { padding-left: 20px; }
+  </style>
+</head>
+<body>
+  <label><input type="checkbox" id="debugToggle"> Debug</label>
+  <div>
+    <input type="file" id="folderPicker" webkitdirectory multiple>
+  </div>
+  <div id="folderDisplay"></div>
+  <ul id="fileList"></ul>
+  <script>
+    const debugToggle = document.getElementById('debugToggle');
+    const folderPicker = document.getElementById('folderPicker');
+    const folderDisplay = document.getElementById('folderDisplay');
+    const fileList = document.getElementById('fileList');
+
+    let debug = false;
+
+    function log(...args) {
+      if (debug) {
+        console.log(...args);
+      }
+    }
+
+    debugToggle.addEventListener('change', () => {
+      debug = debugToggle.checked;
+      log('Debug mode:', debug);
+    });
+
+    folderPicker.addEventListener('change', (e) => {
+      const files = Array.from(e.target.files).filter(f => f.name.endsWith('.md'));
+      if (files.length === 0) {
+        folderDisplay.textContent = 'No markdown files found.';
+        fileList.innerHTML = '';
+        log('No markdown files found');
+        return;
+      }
+
+      const firstPath = files[0].webkitRelativePath;
+      const folderPath = firstPath.substring(0, firstPath.lastIndexOf('/'));
+      folderDisplay.textContent = 'Selected folder: ' + folderPath;
+      log('Selected folder:', folderPath);
+
+      const limit = debug ? 1 : 10;
+      const names = files.slice(0, limit).map(f => f.name);
+      fileList.innerHTML = names.map(n => `<li>${n}</li>`).join('');
+
+      names.forEach(name => log('Processed file:', name));
+      log('Done');
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- ported test_020 popup into a standalone HTML page
- documented usage of the new page
- removed extension log file writes so test_020 no longer crashes after folder selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c56634154c8322b3e22909757ce01f