### PR TITLE
Add nginx load balancer with three backend replicas

### DIFF
--- a/gus/README.md
+++ b/gus/README.md
@@ -10,7 +10,7 @@
 - **Особый режим для Никиты**: пользователь `Никита` или `nikita` может нажимать на гуся, но всегда остаётся с нулём очков.
 - **Яркий молодёжный UI**: неоновые градиенты, крупная типографика и акцентные кнопки.
 - **Консистентность данных**: все операции по тапу выполняются в транзакции PostgreSQL, используются блокировки строк.
-- **Docker-compose** для быстрого запуска всего стека (PostgreSQL + backend + frontend).
+- **Docker-compose** для быстрого запуска всего стека (PostgreSQL + 3 экземпляра backend за nginx + frontend).
 
 ## Архитектура
 
@@ -27,6 +27,7 @@
    │  ├─ src/components
    │  └─ src/styles
    ├─ docker-compose.yml
+   ├─ nginx           # конфигурация балансировщика нагрузки
    ├─ .github/workflows
    └─ README.md (вы тут)
 ```
@@ -82,7 +83,7 @@ docker compose up --build
 - Перед запуском убедитесь, что Docker Engine (Docker Desktop или демон Docker) запущен, иначе команды `docker compose` завершатся с ошибкой подключения.
 
 - `http://localhost:5173` — SPA.
-- `http://localhost:3000` — Fastify API.
+- `http://localhost:3000` — Nginx, распределяющий запросы по трём контейнерам backend.
 - База данных доступна по `localhost:5432` (логин/пароль postgres/postgres).
 
 ### Тестовые аккаунты

--- a/gus/docker-compose.yml
+++ b/gus/docker-compose.yml
@@ -9,7 +9,8 @@ services:
       - '5432:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
-  backend:
+
+  backend-1:
     build:
       context: ./backend
       dockerfile: Dockerfile
@@ -21,15 +22,52 @@ services:
       PORT: 3000
     depends_on:
       - db
+
+  backend-2:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@db:5432/guss
+      JWT_SECRET: supersecretjwtkeysuper
+      ROUND_DURATION: 60
+      COOLDOWN_DURATION: 30
+      PORT: 3000
+    depends_on:
+      - db
+
+  backend-3:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@db:5432/guss
+      JWT_SECRET: supersecretjwtkeysuper
+      ROUND_DURATION: 60
+      COOLDOWN_DURATION: 30
+      PORT: 3000
+    depends_on:
+      - db
+
+  nginx:
+    image: nginx:1.25-alpine
+    depends_on:
+      - backend-1
+      - backend-2
+      - backend-3
     ports:
       - '3000:3000'
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+
   frontend:
     build:
       context: ./frontend
       dockerfile: Dockerfile
     depends_on:
-      - backend
+      - nginx
     ports:
       - '5173:5173'
+
 volumes:
   postgres_data:

--- a/gus/nginx/default.conf
+++ b/gus/nginx/default.conf
@@ -1,0 +1,18 @@
+upstream backend_pool {
+  server backend-1:3000;
+  server backend-2:3000;
+  server backend-3:3000;
+}
+
+server {
+  listen 3000;
+
+  location / {
+    proxy_pass http://backend_pool;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+}


### PR DESCRIPTION
## Summary
- run three backend containers in docker-compose and expose them via an nginx load balancer
- add nginx configuration for proxying requests to the backend pool
- document the new nginx layer and backend replicas in the README

## Testing
- docker compose config *(fails: docker not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfde31fc1083228e9127a3b7fa694d