### PR TITLE
Improve responsive layout for gus frontend

### DIFF
--- a/gus/frontend/src/pages/LoginPage.tsx
+++ b/gus/frontend/src/pages/LoginPage.tsx
@@ -26,10 +26,10 @@ export function LoginPage() {
 
   return (
     <div className="app-shell">
-      <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '24px 32px' }}>
+      <div className="top-bar">
         <LanguageSwitcher />
       </div>
-      <main className="app-main">
+      <main className="app-main login-layout">
         <form className="form-card" onSubmit={handleSubmit}>
           <h2>{t.login.title}</h2>
           <label>

--- a/gus/frontend/src/pages/RoundDetailPage.tsx
+++ b/gus/frontend/src/pages/RoundDetailPage.tsx
@@ -318,7 +318,7 @@ export function RoundDetailPage() {
       {roundQuery.isLoading && <p>{t.roundDetail.loading}</p>}
       {roundQuery.data && (
         <div className="round-layout">
-          <Link to="/rounds" className="link-button">
+          <Link to="/rounds" className="link-button round-detail-back">
             {t.roundDetail.goBack}
           </Link>
           <section className="gus-panel">
@@ -340,11 +340,11 @@ export function RoundDetailPage() {
             <div>
               <p className="score-label">{t.roundDetail.myScoreLabel}</p>
               <p className="score-value">{roundQuery.data.myScore}</p>
-              <p style={{ opacity: 0.6, margin: '8px 0 0 0' }}>
+              <p className="score-meta">
                 {t.roundDetail.taps(roundQuery.data.myTaps)}
               </p>
               {user?.role === 'nikita' && (
-                <p style={{ opacity: 0.7, fontSize: 14 }}>
+                <p className="nikita-warning">
                   {t.roundDetail.nikitaWarning}
                 </p>
               )}
@@ -353,18 +353,18 @@ export function RoundDetailPage() {
 
           {roundQuery.data.status === 'finished' && (
             <section className="stats-card">
-              <h3 style={{ margin: 0, fontSize: 24 }}>{t.roundDetail.stats.heading}</h3>
-              <p style={{ margin: 0 }}>{t.roundDetail.stats.totalScore(roundQuery.data.totalScore)}</p>
+              <h3 className="stats-heading">{t.roundDetail.stats.heading}</h3>
+              <p className="stats-text">{t.roundDetail.stats.totalScore(roundQuery.data.totalScore)}</p>
               {roundQuery.data.winner ? (
-                <p style={{ margin: 0 }}>
+                <p className="stats-text">
                   {t.roundDetail.stats.winnerPrefix}{' '}
                   <strong>{roundQuery.data.winner.username}</strong>{' '}
                   {t.roundDetail.stats.winnerSuffix(roundQuery.data.winner.score)}
                 </p>
               ) : (
-                <p style={{ margin: 0 }}>{t.roundDetail.stats.noWinner}</p>
+                <p className="stats-text">{t.roundDetail.stats.noWinner}</p>
               )}
-              <p style={{ margin: 0 }}>{t.roundDetail.stats.yourResult(roundQuery.data.myScore)}</p>
+              <p className="stats-text">{t.roundDetail.stats.yourResult(roundQuery.data.myScore)}</p>
             </section>
           )}
           {(errorKey || serverError) && (

--- a/gus/frontend/src/pages/RoundsPage.tsx
+++ b/gus/frontend/src/pages/RoundsPage.tsx
@@ -52,10 +52,10 @@ export function RoundsPage() {
 
   return (
     <AppLayout>
-      <div className="rounds-header" style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 32 }}>
-        <div>
-          <h2 style={{ margin: 0, fontSize: 32 }}>{t.rounds.heading}</h2>
-          <p style={{ marginTop: 8, opacity: 0.8 }}>{t.rounds.subtitle}</p>
+      <div className="rounds-header">
+        <div className="rounds-heading-group">
+          <h2 className="rounds-heading">{t.rounds.heading}</h2>
+          <p className="rounds-subtitle">{t.rounds.subtitle}</p>
         </div>
         {user?.role === 'admin' && (
           <button className="button" onClick={handleCreateRound}>
@@ -80,7 +80,7 @@ export function RoundsPage() {
               <p className="card-time">
                 {t.rounds.endLabel}: {new Date(round.endTime).toLocaleString(language === 'ru' ? 'ru-RU' : 'en-US')}
               </p>
-              <Link to={`/rounds/${round.id}`} className="link-button" style={{ marginTop: 16 }}>
+              <Link to={`/rounds/${round.id}`} className="link-button">
                 {t.rounds.view}
               </Link>
             </article>
@@ -88,7 +88,7 @@ export function RoundsPage() {
           {roundsQuery.data?.length === 0 && <p>{t.rounds.empty}</p>}
         </div>
       )}
-      {creationError && <p className="error-text" style={{ marginTop: 24 }}>{t.rounds.errors.create}</p>}
+      {creationError && <p className="error-text creation-error">{t.rounds.errors.create}</p>}
     </AppLayout>
   );
 }

--- a/gus/frontend/src/styles/global.css
+++ b/gus/frontend/src/styles/global.css
@@ -2,12 +2,21 @@
   font-family: 'Jost', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   color: #fff;
   background: #1a1026;
+  line-height: 1.6;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
   background: radial-gradient(circle at top left, #ff7ce6 0%, #6320ee 40%, #0b1026 100%);
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+}
+
+#root {
+  flex: 1;
+  display: flex;
 }
 
 * {
@@ -15,18 +24,26 @@ body {
 }
 
 .app-shell {
+  flex: 1;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  background: linear-gradient(135deg, rgba(255, 92, 135, 0.9), rgba(99, 32, 238, 0.8));
+  background: linear-gradient(135deg, rgba(255, 92, 135, 0.9), rgba(99, 32, 238, 0.82));
   backdrop-filter: blur(16px);
+  border-radius: 32px;
+  overflow: hidden;
+  max-width: 1280px;
+  margin: 0 auto;
+  box-shadow: 0 24px 80px rgba(6, 7, 20, 0.55);
 }
 
 .app-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 24px 48px;
+  flex-wrap: wrap;
+  gap: clamp(16px, 3vw, 32px);
+  padding: clamp(20px, 4vw, 32px) clamp(24px, 5vw, 48px);
   background: rgba(12, 13, 38, 0.35);
   backdrop-filter: blur(16px);
   border-bottom: 1px solid rgba(255, 255, 255, 0.25);
@@ -43,7 +60,9 @@ body {
 .app-profile {
   display: flex;
   align-items: center;
-  gap: 20px;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: clamp(12px, 2vw, 20px);
 }
 
 .language-switcher {
@@ -82,9 +101,12 @@ body {
 
 .app-main {
   flex: 1;
-  width: min(960px, 100%);
+  width: min(1040px, 100%);
   margin: 0 auto;
-  padding: 48px 24px 96px;
+  padding: clamp(24px, 6vh, 64px) clamp(20px, 5vw, 56px) clamp(48px, 10vh, 80px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(24px, 6vh, 48px);
 }
 
 .card-grid {
@@ -99,6 +121,9 @@ body {
   padding: 28px;
   box-shadow: 0 20px 40px rgba(6, 7, 20, 0.5);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .card:hover {
@@ -116,11 +141,11 @@ body {
 
 .card-title {
   font-size: 24px;
-  margin: 12px 0 8px 0;
+  margin: 0;
 }
 
 .card-time {
-  margin: 6px 0;
+  margin: 0;
   font-size: 14px;
   opacity: 0.8;
 }
@@ -180,8 +205,8 @@ body {
 
 .form-card {
   max-width: 400px;
-  margin: 120px auto;
-  padding: 40px;
+  margin: 0 auto;
+  padding: clamp(28px, 5vw, 40px);
   background: rgba(12, 13, 38, 0.75);
   border-radius: 28px;
   box-shadow: 0 30px 60px rgba(6, 7, 20, 0.6);
@@ -213,22 +238,24 @@ body {
 
 .round-layout {
   display: grid;
-  gap: 32px;
+  gap: clamp(20px, 4vw, 32px);
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
 }
 
 .gus-panel {
   background: rgba(12, 13, 38, 0.6);
   border-radius: 32px;
-  padding: 32px;
+  padding: clamp(24px, 5vw, 32px);
   display: grid;
-  gap: 24px;
+  gap: clamp(16px, 4vw, 24px);
   justify-items: center;
   text-align: center;
   position: relative;
 }
 
 .gus-art {
-  width: 220px;
+  width: clamp(160px, 26vw, 220px);
   aspect-ratio: 1;
   border-radius: 50%;
   background: radial-gradient(circle at 30% 30%, rgba(255, 230, 107, 0.9), rgba(255, 124, 230, 0.4));
@@ -261,12 +288,33 @@ body {
   margin: 0;
 }
 
+.score-meta {
+  margin: 8px 0 0;
+  font-size: 14px;
+  opacity: 0.65;
+}
+
+.nikita-warning {
+  margin: 8px 0 0;
+  opacity: 0.7;
+  font-size: 14px;
+}
+
 .stats-card {
   background: rgba(12, 13, 38, 0.55);
   border-radius: 24px;
-  padding: 24px;
+  padding: clamp(20px, 4vw, 28px);
   display: grid;
-  gap: 12px;
+  gap: clamp(12px, 2vw, 16px);
+}
+
+.stats-heading {
+  margin: 0;
+  font-size: clamp(20px, 3vw, 24px);
+}
+
+.stats-text {
+  margin: 0;
 }
 
 .link-button {
@@ -283,6 +331,63 @@ body {
   opacity: 0.8;
 }
 
+.card .link-button {
+  margin-top: auto;
+}
+
+.round-detail-back {
+  justify-self: start;
+}
+
+.top-bar {
+  display: flex;
+  justify-content: flex-end;
+  padding: clamp(16px, 4vw, 28px) clamp(20px, 5vw, 32px) 0;
+}
+
+.login-layout {
+  justify-content: center;
+  align-items: center;
+}
+
+.rounds-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: clamp(16px, 4vw, 24px);
+}
+
+.rounds-heading-group {
+  display: grid;
+  gap: 8px;
+}
+
+.rounds-heading {
+  margin: 0;
+  font-size: clamp(24px, 3vw, 32px);
+}
+
+.rounds-subtitle {
+  margin: 0;
+  opacity: 0.8;
+}
+
+.creation-error {
+  margin-top: 24px;
+}
+
+@media (min-width: 960px) {
+  .round-layout {
+    grid-template-columns: minmax(0, 1.1fr) minmax(260px, 0.9fr);
+    align-items: start;
+  }
+
+  .gus-panel {
+    align-self: stretch;
+  }
+}
+
 @media (max-width: 720px) {
   .app-header {
     flex-direction: column;
@@ -291,10 +396,56 @@ body {
   }
 
   .app-main {
-    padding: 32px 16px 64px;
+    padding: 32px 18px 56px;
   }
 
   .form-card {
-    margin: 80px 16px;
+    width: 100%;
+  }
+
+  .rounds-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 560px) {
+  body {
+    align-items: flex-start;
+  }
+
+  .app-shell {
+    border-radius: 0;
+    min-height: 100vh;
+  }
+
+  .app-header {
+    padding: 20px 18px 16px;
+  }
+
+  .app-logo {
+    font-size: 24px;
+  }
+
+  .app-main {
+    padding: 24px 16px 48px;
+    gap: 32px;
+  }
+
+  .form-card {
+    padding: 24px 20px;
+    border-radius: 20px;
+  }
+
+  .gus-panel {
+    padding: 24px 18px;
+  }
+
+  .gus-panel .button {
+    width: 100%;
+  }
+
+  .top-bar {
+    padding-inline: 16px;
   }
 }


### PR DESCRIPTION
## Summary
- refresh the gus layout with responsive spacing and typography for desktop, tablet, and mobile breakpoints
- refactor page headers and round detail styling to rely on reusable CSS classes instead of inline styles
- center the login flow and language picker while keeping cards and stats panels flexible across screen sizes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e05715bb0c83229ad85adc04d70356