### PR TITLE
Refactor gus frontend layout to match responsive spec

### DIFF
--- a/gus/frontend/src/components/AppLayout.tsx
+++ b/gus/frontend/src/components/AppLayout.tsx
@@ -10,23 +10,27 @@ export function AppLayout({ children }: PropsWithChildren) {
   return (
     <div className="app-shell">
       <header className="app-header">
-        <h1 className="app-logo">{t.app.title}</h1>
-        <div className="app-profile">
-          <LanguageSwitcher />
-          {user && (
-            <>
-              <div>
-                <p className="app-profile-label">{t.app.profileLabel}</p>
-                <p className="app-profile-name">{user.username}</p>
+        <div className="container app-header-inner" data-flow="auto">
+          <h1 className="app-logo">{t.app.title}</h1>
+          <div className="app-actions">
+            <LanguageSwitcher />
+            {user && (
+              <div className="app-profile">
+                <div>
+                  <p className="app-profile-label">{t.app.profileLabel}</p>
+                  <p className="app-profile-name">{user.username}</p>
+                </div>
+                <button onClick={logout} className="button button-outline button-inline">
+                  {t.app.logout}
+                </button>
               </div>
-              <button onClick={logout} className="button button-outline">
-                {t.app.logout}
-              </button>
-            </>
-          )}
+            )}
+          </div>
         </div>
       </header>
-      <main className="app-main">{children}</main>
+      <main className="app-main">
+        <div className="container app-main-inner">{children}</div>
+      </main>
     </div>
   );
 }

--- a/gus/frontend/src/context/LanguageContext.tsx
+++ b/gus/frontend/src/context/LanguageContext.tsx
@@ -22,6 +22,7 @@ const translations = {
       usernamePlaceholder: 'Например, GooseSlayer',
       passwordLabel: 'Пароль',
       passwordPlaceholder: 'Секретная фраза',
+      helper: 'Подключайтесь к центру управления Гусем, чтобы следить за раундами и зарабатывать очки.',
       submit: {
         idle: 'Влететь в бой',
         loading: 'Проверяем...'
@@ -102,6 +103,7 @@ const translations = {
       usernamePlaceholder: 'For example, GooseSlayer',
       passwordLabel: 'Password',
       passwordPlaceholder: 'Secret phrase',
+      helper: 'Connect to the Goose control hub to monitor rounds and earn points.',
       submit: {
         idle: 'Join the fight',
         loading: 'Checking...'

--- a/gus/frontend/src/pages/LoginPage.tsx
+++ b/gus/frontend/src/pages/LoginPage.tsx
@@ -25,41 +25,60 @@ export function LoginPage() {
   };
 
   return (
-    <div className="app-shell">
-      <div className="top-bar">
-        <LanguageSwitcher />
-      </div>
-      <main className="app-main login-layout">
-        <form className="form-card" onSubmit={handleSubmit}>
-          <h2>{t.login.title}</h2>
-          <label>
-            {t.login.usernameLabel}
-            <input
-              className="text-field"
-              value={username}
-              onChange={(event) => setUsername(event.target.value)}
-              placeholder={t.login.usernamePlaceholder}
-              autoComplete="username"
-              required
-            />
-          </label>
-          <label>
-            {t.login.passwordLabel}
-            <input
-              className="text-field"
-              type="password"
-              value={password}
-              onChange={(event) => setPassword(event.target.value)}
-              placeholder={t.login.passwordPlaceholder}
-              autoComplete="current-password"
-              required
-            />
-          </label>
-          <button className="button" type="submit" disabled={loading}>
-            {loading ? t.login.submit.loading : t.login.submit.idle}
-          </button>
-          {hasError && <p className="error-text">{t.login.errors.generic}</p>}
-        </form>
+    <div className="auth-shell">
+      <header className="auth-header">
+        <div className="container auth-header-inner" data-flow="auto">
+          <h1 className="app-logo">{t.app.title}</h1>
+          <LanguageSwitcher />
+        </div>
+      </header>
+      <main className="auth-main">
+        <div className="container auth-content" data-flow="auto">
+          <section className="surface-card auth-form" data-flow="column">
+            <h2>{t.login.title}</h2>
+            <form onSubmit={handleSubmit} className="stack">
+              <label>
+                {t.login.usernameLabel}
+                <input
+                  className="text-field"
+                  value={username}
+                  onChange={(event) => setUsername(event.target.value)}
+                  placeholder={t.login.usernamePlaceholder}
+                  autoComplete="username"
+                  required
+                />
+              </label>
+              <label>
+                {t.login.passwordLabel}
+                <input
+                  className="text-field"
+                  type="password"
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
+                  placeholder={t.login.passwordPlaceholder}
+                  autoComplete="current-password"
+                  required
+                />
+              </label>
+              <button className="button" type="submit" disabled={loading}>
+                {loading ? t.login.submit.loading : t.login.submit.idle}
+              </button>
+              {hasError && (
+                <p className="error-text" role="alert">
+                  {t.login.errors.generic}
+                </p>
+              )}
+            </form>
+          </section>
+          <aside className="auth-visual">
+            <div className="auth-illustration" aria-hidden="true" role="presentation">
+              🦆
+            </div>
+            <div className="text-block">
+              <p>{t.login.helper}</p>
+            </div>
+          </aside>
+        </div>
       </main>
     </div>
   );

--- a/gus/frontend/src/pages/RoundDetailPage.tsx
+++ b/gus/frontend/src/pages/RoundDetailPage.tsx
@@ -314,68 +314,105 @@ export function RoundDetailPage() {
 
   return (
     <AppLayout>
-      {roundQuery.isError && <p className="error-text">{t.roundDetail.fetchError}</p>}
-      {roundQuery.isLoading && <p>{t.roundDetail.loading}</p>}
-      {roundQuery.data && (
-        <div className="round-layout">
-          <Link to="/rounds" className="link-button round-detail-back">
-            {t.roundDetail.goBack}
-          </Link>
-          <div className="round-columns">
-            <section className="gus-panel">
-              <span className="timer-badge">{statusBadge}</span>
-              <div className="gus-art" role="button" aria-pressed={false}>
-                🦆
-              </div>
-              <button
-                className="button"
-                onClick={handleTap}
-                disabled={roundQuery.data.status !== 'active' || isTapping}
-              >
-                {buttonLabel}
-              </button>
-              <div>
-                <p className="score-label">{t.roundDetail.timeLabel}</p>
-                <p className="score-value">{remaining}</p>
-              </div>
-              <div>
-                <p className="score-label">{t.roundDetail.myScoreLabel}</p>
-                <p className="score-value">{roundQuery.data.myScore}</p>
-                <p className="score-meta">
-                  {t.roundDetail.taps(roundQuery.data.myTaps)}
-                </p>
-                {user?.role === 'nikita' && (
-                  <p className="nikita-warning">
-                    {t.roundDetail.nikitaWarning}
-                  </p>
-                )}
-              </div>
-            </section>
+      <section className="page-section round-layout">
+        <Link to="/rounds" className="link-button round-detail-back">
+          {t.roundDetail.goBack}
+        </Link>
 
-            {roundQuery.data.status === 'finished' && (
-              <section className="stats-card">
-                <h3 className="stats-heading">{t.roundDetail.stats.heading}</h3>
-                <p className="stats-text">{t.roundDetail.stats.totalScore(roundQuery.data.totalScore)}</p>
-                {roundQuery.data.winner ? (
-                  <p className="stats-text">
-                    {t.roundDetail.stats.winnerPrefix}{' '}
-                    <strong>{roundQuery.data.winner.username}</strong>{' '}
-                    {t.roundDetail.stats.winnerSuffix(roundQuery.data.winner.score)}
-                  </p>
-                ) : (
-                  <p className="stats-text">{t.roundDetail.stats.noWinner}</p>
-                )}
-                <p className="stats-text">{t.roundDetail.stats.yourResult(roundQuery.data.myScore)}</p>
-              </section>
-            )}
-          </div>
-          {(errorKey || serverError) && (
-            <p className="error-text">
-              {serverError ?? (errorKey ? t.roundDetail.errors[errorKey] : null)}
+        {roundQuery.isError && (
+          <p className="error-text" role="alert">
+            {t.roundDetail.fetchError}
+          </p>
+        )}
+
+        {roundQuery.isLoading && (
+          <>
+            <p className="sr-only" role="status" aria-live="polite">
+              {t.roundDetail.loading}
             </p>
-          )}
-        </div>
-      )}
+            <div className="surface-card round-skeleton skeleton" aria-hidden="true" />
+          </>
+        )}
+
+        {roundQuery.data && (
+          <>
+            <div className="round-sections" data-flow="auto">
+              <section className="surface-card goose-panel">
+                <span className="status-badge">{statusBadge}</span>
+                <button
+                  type="button"
+                  className="goose-hit-target"
+                  onClick={handleTap}
+                  disabled={
+                    roundQuery.data.status !== 'active' || isTapping || !socketReady
+                  }
+                  aria-label={buttonLabel}
+                  title={buttonLabel}
+                >
+                  🦆
+                </button>
+                <div className="metrics-group">
+                  <div className="metric-block">
+                    <span className="metric-label">{t.roundDetail.timeLabel}</span>
+                    <span className="metric-value timer-value">{remaining}</span>
+                  </div>
+                  <div className="metric-block">
+                    <span className="metric-label">{t.roundDetail.myScoreLabel}</span>
+                    <span className="metric-value">{roundQuery.data.myScore}</span>
+                    <p className="metric-caption">
+                      {t.roundDetail.taps(roundQuery.data.myTaps)}
+                    </p>
+                    {user?.role === 'nikita' && (
+                      <p className="nikita-warning metric-caption">
+                        {t.roundDetail.nikitaWarning}
+                      </p>
+                    )}
+                  </div>
+                </div>
+                <button
+                  className="button button-inline"
+                  type="button"
+                  onClick={handleTap}
+                  disabled={
+                    roundQuery.data.status !== 'active' || isTapping || !socketReady
+                  }
+                >
+                  {buttonLabel}
+                </button>
+              </section>
+
+              {roundQuery.data.status === 'finished' && (
+                <section className="surface-card round-status-panel text-block">
+                  <h3 className="stats-heading">{t.roundDetail.stats.heading}</h3>
+                  <p className="stats-text">
+                    {t.roundDetail.stats.totalScore(roundQuery.data.totalScore)}
+                  </p>
+                  {roundQuery.data.winner ? (
+                    <p className="stats-text">
+                      {t.roundDetail.stats.winnerPrefix}{' '}
+                      <strong>{roundQuery.data.winner.username}</strong>{' '}
+                      {t.roundDetail.stats.winnerSuffix(roundQuery.data.winner.score)}
+                    </p>
+                  ) : (
+                    <p className="stats-text">{t.roundDetail.stats.noWinner}</p>
+                  )}
+                  <p className="stats-text">
+                    {t.roundDetail.stats.yourResult(roundQuery.data.myScore)}
+                  </p>
+                </section>
+              )}
+            </div>
+
+            {(errorKey || serverError) && (
+              <div className="round-errors" role="alert">
+                <p className="error-text">
+                  {serverError ?? (errorKey ? t.roundDetail.errors[errorKey] : null)}
+                </p>
+              </div>
+            )}
+          </>
+        )}
+      </section>
     </AppLayout>
   );
 }

--- a/gus/frontend/src/pages/RoundsPage.tsx
+++ b/gus/frontend/src/pages/RoundsPage.tsx
@@ -52,43 +52,64 @@ export function RoundsPage() {
 
   return (
     <AppLayout>
-      <div className="rounds-header">
-        <div className="rounds-heading-group">
-          <h2 className="rounds-heading">{t.rounds.heading}</h2>
-          <p className="rounds-subtitle">{t.rounds.subtitle}</p>
-        </div>
-        {user?.role === 'admin' && (
-          <button className="button" onClick={handleCreateRound}>
-            {t.rounds.create}
-          </button>
-        )}
-      </div>
+      <section className="page-section">
+        <header className="rounds-header" data-flow="auto">
+          <div className="rounds-heading-group text-block">
+            <h2 className="rounds-heading">{t.rounds.heading}</h2>
+            <p className="rounds-subtitle">{t.rounds.subtitle}</p>
+          </div>
+          {user?.role === 'admin' && (
+            <button className="button button-inline" onClick={handleCreateRound}>
+              {t.rounds.create}
+            </button>
+          )}
+        </header>
 
-      {roundsQuery.isError ? (
-        <p className="error-text">{t.rounds.errors.list}</p>
-      ) : roundsQuery.isLoading ? (
-        <p>{t.rounds.loading}</p>
-      ) : (
-        <div className="card-grid">
-          {roundsQuery.data?.map((round) => (
-            <article key={round.id} className="card">
-              <p className="card-status">{t.rounds.status[round.status]}</p>
-              <h3 className="card-title">{t.rounds.cardTitle(round.id.slice(0, 8))}</h3>
-              <p className="card-time">
-                {t.rounds.startLabel}: {new Date(round.startTime).toLocaleString(language === 'ru' ? 'ru-RU' : 'en-US')}
-              </p>
-              <p className="card-time">
-                {t.rounds.endLabel}: {new Date(round.endTime).toLocaleString(language === 'ru' ? 'ru-RU' : 'en-US')}
-              </p>
-              <Link to={`/rounds/${round.id}`} className="link-button">
-                {t.rounds.view}
-              </Link>
-            </article>
-          ))}
-          {roundsQuery.data?.length === 0 && <p>{t.rounds.empty}</p>}
-        </div>
-      )}
-      {creationError && <p className="error-text creation-error">{t.rounds.errors.create}</p>}
+        {roundsQuery.isError ? (
+          <p className="error-text" role="alert">
+            {t.rounds.errors.list}
+          </p>
+        ) : roundsQuery.isLoading ? (
+          <>
+            <p className="sr-only" role="status" aria-live="polite">
+              {t.rounds.loading}
+            </p>
+            <div className="card-grid" aria-hidden="true">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <article key={index} className="card card--skeleton skeleton" />
+              ))}
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="card-grid">
+              {roundsQuery.data?.map((round) => (
+                <article key={round.id} className="card">
+                  <p className="card-status">{t.rounds.status[round.status]}</p>
+                  <h3 className="card-title">{t.rounds.cardTitle(round.id.slice(0, 8))}</h3>
+                  <p className="card-time">
+                    {t.rounds.startLabel}:{' '}
+                    {new Date(round.startTime).toLocaleString(language === 'ru' ? 'ru-RU' : 'en-US')}
+                  </p>
+                  <p className="card-time">
+                    {t.rounds.endLabel}:{' '}
+                    {new Date(round.endTime).toLocaleString(language === 'ru' ? 'ru-RU' : 'en-US')}
+                  </p>
+                  <Link to={`/rounds/${round.id}`} className="link-button">
+                    {t.rounds.view}
+                  </Link>
+                </article>
+              ))}
+            </div>
+            {roundsQuery.data?.length === 0 && <p className="empty-state text-block">{t.rounds.empty}</p>}
+          </>
+        )}
+        {creationError && (
+          <p className="error-text creation-error" role="alert">
+            {t.rounds.errors.create}
+          </p>
+        )}
+      </section>
     </AppLayout>
   );
 }

--- a/gus/frontend/src/styles/global.css
+++ b/gus/frontend/src/styles/global.css
@@ -1,68 +1,218 @@
 :root {
   font-family: 'Jost', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  color: #fff;
-  background: #1a1026;
-  line-height: 1.6;
+  line-height: 1.5;
+  color: #f8fafc;
+  background-color: #070b1a;
+  text-rendering: optimizeLegibility;
+  --surface-color: rgba(12, 16, 36, 0.78);
+  --surface-border: rgba(148, 163, 184, 0.22);
+  --surface-soft: rgba(12, 16, 36, 0.52);
+  --accent: #fbbf24;
+  --accent-strong: #f97316;
+  --text-primary: #f8fafc;
+  --text-muted: #cbd5f5;
+  --danger: #f87171;
+  --stack-gap: clamp(16px, 3vw, 24px);
+  --row-gap: clamp(24px, 3vw, 32px);
+  --container-padding: 16px;
+  --card-radius: 24px;
+  --shadow-strong: 0 20px 45px rgba(6, 8, 24, 0.55);
+  --shadow-soft: 0 10px 30px rgba(7, 10, 28, 0.4);
 }
 
-body {
-  margin: 0;
-  min-height: 100vh;
-  background: radial-gradient(circle at top left, #ff7ce6 0%, #6320ee 40%, #0b1026 100%);
-  display: flex;
-  justify-content: center;
-  align-items: stretch;
+@media (min-width: 481px) {
+  :root {
+    --container-padding: 20px;
+  }
 }
 
-#root {
-  flex: 1;
-  display: flex;
+@media (min-width: 769px) {
+  :root {
+    --container-padding: 24px;
+  }
+}
+
+@media (min-width: 1025px) {
+  :root {
+    --container-padding: 32px;
+  }
 }
 
 * {
   box-sizing: border-box;
 }
 
-.app-shell {
-  flex: 1;
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #1f2a61 0%, #0b1026 45%, #050712 100%);
+  color: var(--text-primary);
+  position: relative;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at 12% 16%, rgba(249, 115, 22, 0.18), transparent 45%),
+    radial-gradient(circle at 82% 8%, rgba(14, 165, 233, 0.18), transparent 40%),
+    linear-gradient(135deg, rgba(10, 15, 32, 0.8), rgba(3, 6, 18, 0.85));
+  z-index: -1;
+}
+
+body,
+button,
+input,
+select,
+textarea {
+  font: inherit;
+  color: inherit;
+}
+
+button,
+input,
+select,
+textarea {
+  background-color: transparent;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:disabled,
+.button:disabled {
+  cursor: not-allowed;
+}
+
+button:focus-visible,
+a:focus-visible,
+select:focus-visible,
+input:focus-visible,
+.goose-hit-target:focus-visible {
+  outline: 3px solid rgba(251, 191, 36, 0.75);
+  outline-offset: 3px;
+}
+
+#root {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  background: linear-gradient(135deg, rgba(255, 92, 135, 0.9), rgba(99, 32, 238, 0.82));
-  backdrop-filter: blur(16px);
-  border-radius: 32px;
-  overflow: hidden;
-  max-width: 1280px;
-  margin: 0 auto;
-  box-shadow: 0 24px 80px rgba(6, 7, 20, 0.55);
+}
+
+.container {
+  width: min(100%, clamp(320px, 92vw, 1200px));
+  margin-inline: auto;
+  padding-inline: var(--container-padding);
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--stack-gap);
+  align-items: flex-start;
+  width: 100%;
+}
+
+[data-flow='column'],
+[data-flow='auto'] {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--stack-gap);
+  width: 100%;
+}
+
+[data-flow='row'] {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: var(--row-gap);
+  width: 100%;
+}
+
+@media (min-width: 769px) {
+  [data-flow='auto'] {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: var(--row-gap);
+  }
+}
+
+[data-flow] > * {
+  flex: 0 1 auto;
+  min-width: 0;
+  align-self: flex-start;
+}
+
+.text-block {
+  max-width: 65ch;
+  height: auto;
+  align-self: flex-start;
+}
+
+.text-block p {
+  margin: 0;
+}
+
+.text-block p + p {
+  margin-top: 0.75em;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  backdrop-filter: blur(18px);
+  background: linear-gradient(140deg, rgba(12, 16, 36, 0.82), rgba(6, 9, 26, 0.78));
 }
 
 .app-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: clamp(16px, 3vw, 32px);
-  padding: clamp(20px, 4vw, 32px) clamp(24px, 5vw, 48px);
-  background: rgba(12, 13, 38, 0.35);
-  backdrop-filter: blur(16px);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.25);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(7, 11, 27, 0.76);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.app-header-inner {
+  padding-block: clamp(16px, 3vw, 28px);
 }
 
 .app-logo {
-  font-size: 32px;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
   margin: 0;
+  font-size: clamp(20px, 5vw, 30px);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.app-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(12px, 2.8vw, 20px);
+  align-items: flex-start;
 }
 
 .app-profile {
   display: flex;
-  align-items: center;
-  justify-content: center;
   flex-wrap: wrap;
-  gap: clamp(12px, 2vw, 20px);
+  gap: clamp(12px, 2vw, 16px);
+  align-items: flex-start;
 }
 
 .language-switcher {
@@ -70,310 +220,187 @@ body {
   align-items: center;
   gap: 8px;
   font-size: 14px;
+  color: var(--text-muted);
 }
 
 .language-select {
-  background: rgba(12, 13, 38, 0.55);
-  border: 1px solid rgba(255, 255, 255, 0.4);
-  border-radius: 12px;
-  color: #fff;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
   padding: 6px 12px;
-  font-size: 14px;
+  background: rgba(11, 16, 34, 0.7);
+  color: var(--text-primary);
+  min-height: 32px;
 }
 
-.language-select:focus {
-  outline: none;
-  border-color: rgba(255, 230, 107, 0.9);
-  box-shadow: 0 0 0 3px rgba(255, 230, 107, 0.25);
+.language-select:hover {
+  border-color: rgba(251, 191, 36, 0.6);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .app-profile-label {
   margin: 0;
-  opacity: 0.7;
   font-size: 14px;
+  color: var(--text-muted);
 }
 
 .app-profile-name {
-  margin: 2px 0 0 0;
+  margin: 2px 0 0;
   font-weight: 600;
   font-size: 18px;
 }
 
 .app-main {
   flex: 1;
-  width: min(1040px, 100%);
-  margin: 0 auto;
-  padding: clamp(24px, 6vh, 64px) clamp(20px, 5vw, 56px) clamp(48px, 10vh, 80px);
+  padding-block: clamp(32px, 8vh, 72px);
+}
+
+.app-main-inner {
   display: flex;
   flex-direction: column;
-  gap: clamp(24px, 6vh, 48px);
+  gap: clamp(24px, 7vh, 48px);
+  align-items: flex-start;
+  width: 100%;
 }
 
-.card-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 24px;
-}
-
-.card {
-  background: rgba(12, 13, 38, 0.5);
-  border-radius: 24px;
-  padding: 28px;
-  box-shadow: 0 20px 40px rgba(6, 7, 20, 0.5);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+.page-section {
+  width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--stack-gap);
+  align-items: flex-start;
 }
 
-.card:hover {
-  transform: translateY(-6px);
-  box-shadow: 0 26px 60px rgba(6, 7, 20, 0.55);
-}
-
-.card-status {
-  font-weight: 600;
-  text-transform: uppercase;
-  font-size: 14px;
-  letter-spacing: 0.2em;
-  opacity: 0.85;
-}
-
-.card-title {
-  font-size: 24px;
-  margin: 0;
-}
-
-.card-time {
-  margin: 0;
-  font-size: 14px;
-  opacity: 0.8;
+.surface-card {
+  background: var(--surface-color);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--card-radius);
+  padding: clamp(24px, 5vw, 36px);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(12px, 3vw, 18px);
+  align-items: flex-start;
 }
 
 .button {
   border: none;
   border-radius: 999px;
-  padding: 12px 28px;
+  padding: 0 24px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
   font-weight: 600;
   font-size: 16px;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  background: linear-gradient(135deg, #ffe66b, #ff7ce6);
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
   color: #1a1026;
-  box-shadow: 0 12px 24px rgba(255, 124, 230, 0.35);
+  box-shadow: var(--shadow-soft);
+  transition: transform 150ms ease, box-shadow 150ms ease, filter 150ms ease;
 }
 
-.button:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 16px 30px rgba(255, 124, 230, 0.4);
+.button-inline {
+  width: auto;
+}
+
+@media (max-width: 768px) {
+  .button {
+    min-height: 40px;
+    width: 100%;
+  }
+
+  .button.button-inline {
+    width: auto;
+  }
+}
+
+@media (min-width: 769px) {
+  .button.button-inline {
+    width: auto;
+  }
+}
+
+.button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-strong);
 }
 
 .button:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  transform: none;
+  opacity: 0.6;
   box-shadow: none;
+  transform: none;
 }
 
 .button-outline {
   background: transparent;
-  color: #fff;
-  border: 1px solid rgba(255, 255, 255, 0.5);
+  color: var(--text-primary);
+  border: 1px solid rgba(148, 163, 184, 0.35);
   box-shadow: none;
 }
 
-.button-outline:hover {
-  border-color: #fff;
+.button-outline:hover:not(:disabled) {
+  filter: brightness(1.08);
 }
 
 .text-field {
   width: 100%;
-  padding: 14px 18px;
+  padding: 12px 16px;
   border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  background: rgba(12, 13, 38, 0.55);
-  color: #fff;
-  font-size: 16px;
-  margin-top: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(10, 14, 30, 0.7);
+  color: var(--text-primary);
+  min-height: 44px;
+}
+
+.text-field::placeholder {
+  color: rgba(203, 213, 225, 0.65);
 }
 
 .text-field:focus {
+  border-color: rgba(251, 191, 36, 0.7);
+  box-shadow: 0 0 0 4px rgba(251, 191, 36, 0.18);
   outline: none;
-  border-color: rgba(255, 230, 107, 0.9);
-  box-shadow: 0 0 0 4px rgba(255, 230, 107, 0.25);
 }
 
-.form-card {
-  max-width: 400px;
-  margin: 0 auto;
-  padding: clamp(28px, 5vw, 40px);
-  background: rgba(12, 13, 38, 0.75);
-  border-radius: 28px;
-  box-shadow: 0 30px 60px rgba(6, 7, 20, 0.6);
-}
-
-.form-card h2 {
-  margin-top: 0;
-  margin-bottom: 24px;
-  font-size: 28px;
-}
-
-.form-card label {
-  display: block;
-  margin-bottom: 24px;
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
   font-weight: 500;
-  letter-spacing: 0.04em;
-}
-
-.form-card .button {
-  margin-top: 12px;
-  width: 100%;
+  letter-spacing: 0.02em;
 }
 
 .error-text {
-  color: #ffb3c6;
-  margin-top: 12px;
+  color: var(--danger);
   font-size: 14px;
-}
-
-.round-layout {
-  display: flex;
-  flex-direction: column;
-  gap: clamp(18px, 3.4vw, 28px);
-}
-
-.round-columns {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: clamp(18px, 3.4vw, 28px);
-  align-items: stretch;
-}
-
-.round-columns > * {
-  min-width: 0;
-}
-
-@media (min-width: 860px) {
-  .round-columns {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    align-items: stretch;
-  }
-}
-
-.gus-panel {
-  background: rgba(12, 13, 38, 0.6);
-  border-radius: 32px;
-  padding: clamp(20px, 4.4vw, 28px);
-  display: grid;
-  gap: clamp(12px, 3.2vw, 18px);
-  justify-items: center;
-  text-align: center;
-  position: relative;
-}
-
-.gus-art {
-  width: clamp(140px, 21vw, 200px);
-  aspect-ratio: 1;
-  border-radius: 50%;
-  background: radial-gradient(circle at 30% 30%, rgba(255, 230, 107, 0.9), rgba(255, 124, 230, 0.4));
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 58px;
-  box-shadow: 0 20px 40px rgba(255, 124, 230, 0.35);
-}
-
-.timer-badge {
-  padding: 8px 18px;
-  border-radius: 999px;
-  background: rgba(255, 230, 107, 0.2);
-  color: #ffe66b;
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-  font-size: 12px;
-}
-
-.score-label {
-  font-size: clamp(16px, 2.6vw, 18px);
-  opacity: 0.85;
   margin: 0;
-}
-
-.score-value {
-  font-size: clamp(36px, 7vw, 48px);
-  font-weight: 700;
-  margin: 0;
-}
-
-.score-meta {
-  margin: 6px 0 0;
-  font-size: clamp(13px, 2.4vw, 14px);
-  opacity: 0.65;
-}
-
-.nikita-warning {
-  margin: 8px 0 0;
-  opacity: 0.7;
-  font-size: 14px;
-}
-
-.stats-card {
-  background: rgba(12, 13, 38, 0.55);
-  border-radius: 24px;
-  padding: clamp(16px, 2.8vw, 22px);
-  display: grid;
-  gap: clamp(4px, 1.2vw, 8px);
-}
-
-.stats-heading {
-  margin: 0;
-  font-size: clamp(18px, 2.6vw, 22px);
-}
-
-.stats-text {
-  margin: 0;
-  line-height: 1.18;
 }
 
 .link-button {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  color: #ffe66b;
-  text-decoration: none;
   font-weight: 600;
-  transition: opacity 0.2s ease;
+  color: var(--accent);
 }
 
 .link-button:hover {
-  opacity: 0.8;
-}
-
-.card .link-button {
-  margin-top: auto;
-}
-
-.round-detail-back {
-  align-self: flex-start;
-}
-
-.top-bar {
-  display: flex;
-  justify-content: flex-end;
-  padding: clamp(16px, 4vw, 28px) clamp(20px, 5vw, 32px) 0;
-}
-
-.login-layout {
-  justify-content: center;
-  align-items: center;
+  opacity: 0.85;
 }
 
 .rounds-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: clamp(16px, 4vw, 24px);
+  width: 100%;
 }
 
 .rounds-heading-group {
@@ -383,101 +410,319 @@ body {
 
 .rounds-heading {
   margin: 0;
-  font-size: clamp(24px, 3vw, 32px);
+  font-size: clamp(26px, 5vw, 36px);
 }
 
 .rounds-subtitle {
   margin: 0;
-  opacity: 0.8;
+  color: var(--text-muted);
 }
 
-.creation-error {
-  margin-top: 24px;
+.card-grid {
+  width: 100%;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: clamp(18px, 3vw, 28px);
+  align-content: flex-start;
 }
 
-@media (min-width: 960px) {
-  .stats-card {
+@media (min-width: 769px) {
+  .card-grid {
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  }
+}
+
+.card {
+  background: var(--surface-soft);
+  border: 1px solid var(--surface-border);
+  border-radius: 20px;
+  padding: clamp(20px, 4vw, 28px);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-soft);
+}
+
+.card-status {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--text-muted);
+}
+
+.card-title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 600;
+}
+
+.card-time {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.card .link-button {
+  margin-top: auto;
+}
+
+.skeleton {
+  position: relative;
+  overflow: hidden;
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+  transform: translateX(-100%);
+  animation: shimmer 1200ms ease-in-out infinite;
+}
+
+.card.card--skeleton {
+  height: 188px;
+  border-color: transparent;
+}
+
+.round-skeleton {
+  width: 100%;
+  height: clamp(260px, 60vh, 360px);
+  border-radius: var(--card-radius);
+}
+
+@keyframes shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+.auth-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.auth-header {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(7, 11, 27, 0.76);
+}
+
+.auth-header-inner {
+  padding-block: clamp(16px, 3vw, 24px);
+}
+
+.auth-main {
+  flex: 1;
+  display: flex;
+  align-items: flex-start;
+  padding-block: clamp(32px, 9vh, 80px);
+}
+
+.auth-content {
+  width: 100%;
+}
+
+.auth-form {
+  max-width: 400px;
+  width: min(100%, 400px);
+}
+
+.auth-form .button {
+  margin-top: 8px;
+}
+
+@media (min-width: 769px) {
+  .auth-form .button {
+    width: auto;
+  }
+}
+
+.auth-visual {
+  flex: 1 1 260px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: flex-start;
+  align-self: flex-start;
+}
+
+.auth-illustration {
+  width: clamp(200px, 60vw, 360px);
+  aspect-ratio: 1;
+  border-radius: 32px;
+  background: radial-gradient(circle at 28% 24%, rgba(251, 191, 36, 0.5), rgba(14, 165, 233, 0.25));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(3.5rem, 22vw, 6rem);
+  box-shadow: var(--shadow-soft);
+}
+
+.auth-visual .text-block {
+  color: var(--text-muted);
+}
+
+.round-layout {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--stack-gap);
+  align-items: flex-start;
+}
+
+.round-detail-back {
+  color: var(--text-muted);
+}
+
+.round-sections {
+  width: 100%;
+}
+
+.goose-panel {
+  align-content: flex-start;
+}
+
+.goose-panel .button-inline {
+  align-self: flex-start;
+}
+
+.goose-hit-target {
+  width: clamp(180px, 45vw, 320px);
+  aspect-ratio: 1 / 1;
+  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: radial-gradient(circle at 40% 30%, rgba(251, 191, 36, 0.6), rgba(59, 130, 246, 0.25));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(3.2rem, 20vw, 5rem);
+  box-shadow: var(--shadow-soft);
+  color: #0f172a;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.goose-hit-target[disabled] {
+  filter: grayscale(0.3);
+  opacity: 0.5;
+}
+
+.goose-hit-target:not([disabled]):hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-strong);
+}
+
+.status-badge {
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.18);
+  color: var(--text-muted);
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.metrics-group {
+  display: grid;
+  gap: 12px;
+  align-content: flex-start;
+}
+
+.metric-block {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-start;
+}
+
+.metric-label {
+  font-size: 14px;
+  color: var(--text-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.metric-value {
+  font-size: clamp(28px, 10vw, 44px);
+  font-weight: 700;
+}
+
+.timer-value {
+  font-family: 'Roboto Mono', 'SFMono-Regular', 'Menlo', 'Monaco', monospace;
+}
+
+.metric-caption {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.round-status-panel {
+  align-self: flex-start;
+  align-content: flex-start;
+}
+
+.round-status-panel .stats-heading {
+  margin: 0;
+  font-size: clamp(20px, 4vw, 26px);
+}
+
+.round-status-panel .stats-text {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.nikita-warning {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.round-errors {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+@media (min-width: 769px) {
+  .goose-panel {
+    flex: 1 1 360px;
+  }
+
+  .round-status-panel {
+    flex: 1 1 280px;
+  }
+}
+
+@media (min-width: 1025px) {
+  .goose-hit-target {
     max-width: 360px;
   }
 }
 
-@media (max-width: 720px) {
-  .app-header {
-    flex-direction: column;
-    gap: 16px;
-    text-align: center;
-  }
-
-  .app-main {
-    padding: 32px 18px 56px;
-  }
-
-  .form-card {
-    width: 100%;
-  }
-
-  .rounds-header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
+.creation-error {
+  margin-top: 8px;
 }
 
-@media (max-width: 560px) {
-  body {
-    align-items: flex-start;
-  }
+.empty-state {
+  color: var(--text-muted);
+}
 
-  .app-shell {
-    border-radius: 0;
-    min-height: 100vh;
-  }
-
-  .app-header {
-    padding: 20px 18px 16px;
-  }
-
-  .app-logo {
-    font-size: 24px;
-  }
-
-  .app-main {
-    padding: 20px 16px 40px;
-    gap: 24px;
-  }
-
-  .round-columns {
-    gap: 18px;
-  }
-
-  .form-card {
-    padding: 24px 20px;
-    border-radius: 20px;
-  }
-
-  .gus-panel {
-    padding: 18px 16px;
-    gap: 14px;
-  }
-
-  .gus-panel .button {
-    width: 100%;
-  }
-
-  .gus-art {
-    width: 140px;
-    font-size: 48px;
-  }
-
-  .score-value {
-    font-size: 36px;
-  }
-
-  .stats-card {
-    padding: 16px 16px;
-    gap: 8px;
-  }
-
-  .top-bar {
-    padding-inline: 16px;
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }


### PR DESCRIPTION
## Summary
- reworked the shared layout, spacing system, and flow utilities to support the new mobile-first responsive spec
- redesigned the login screen with a column-to-row switcher layout, helper copy, and decorative goose art
- updated the rounds list and round detail experiences with responsive stacks, skeleton placeholders, and accessible tap interactions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e080b0721083228c3f776aebf9900c