### PR TITLE
Fix gus CI paths for npm commands

### DIFF
--- a/gus/.github/workflows/ci.yml
+++ b/gus/.github/workflows/ci.yml
@@ -8,26 +8,38 @@ on:
 jobs:
   backend:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: gus/backend
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm install
-      - run: npm run build
+      - name: Install dependencies
+        working-directory: backend
+        run: |
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci
+          else
+            npm install
+          fi
+      - name: Build backend
+        working-directory: backend
+        run: npm run build
 
   frontend:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: gus/frontend
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm install
-      - run: npm run build
+      - name: Install dependencies
+        working-directory: frontend
+        run: |
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci
+          else
+            npm install
+          fi
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build


### PR DESCRIPTION
## Summary
- run gus backend and frontend npm steps from their project directories using working-directory
- keep conditional npm ci/npm install logic while removing incorrect gus/ path prefixes

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68e0aafc4e288322b36e22d657f48fba